### PR TITLE
Optional Arguments, Utility function, Chores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 refactor.md
 /env
+/.mypy_cache
+/.pytest_cache
+/__pycache__

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Parent_Specialization_Folder/
 - `-n`/`--no-dirs` is useful to create markdown files for a book, episodic material, etc. This generates only the main _course_ directory, _course index file_, and a formatted _section_ file for each supplied section - no _subsections_.
 - `t`/`--no-toc` will only generate the _table of contents_ in the _course index file_ and **not** an expanded _TOC_ in any _section_ files - but will still create a _TOC_ with a link to the _course index file_. This is useful when the book, episodic material, etc. has many sections which would create a long _TOC_.
   - **Note:** This flag will only work when `-n`/`--no-dirs` is also flagged.
-    `-e <string>`/`--extra <string>` will over-ride the markdown headers below the _table of contents_ to the supplied markdown-formatted string.
-  - **Note:** Recommended to use _single quotes_ to handle terminal-related string issues.
+- `-e <string>`/`--extra <string>` will over-ride the markdown headers below the _table of contents_ to the supplied markdown-formatted string.
+  - **Note:** Recommended to use _single quotes_ to handle terminal-related string escape issues.
   - Example: `py course_setup_md.py -nte '## Transcript\n\n## Vocabulary\n\n## Footnotes'`
 
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Parent_Specialization_Folder/
 
 ## Usage
 
-- Run `python course_setup_md.py`,
+- Run `python course_setup_md.py`, or use one of the [optional arguments](#optional-arguments),
 - User is prompted with a `course number` - can be left blank, otherwise will precede the _course_ directory name with the number, in 2-digit format (e.g. `1` will become `01`),
 - User is prompted with `course title` - can be entered lower-case, and it will generate using _title case_ throughout the markdown files,
 - User is prompted with `short-form title` - this might be a short-hand for the course, or perhaps the program code (e.g. a university might have `BTSA 5510` for the course),
@@ -88,3 +88,46 @@ Parent_Specialization_Folder/
 - User is then prompted for the first _subsection_ - case insensitive and generated using _title case_,
 - Subsequent _subsections_ are prompted, but `CTRL-D` will exit that _section_ and prompt the user for a new _section_ and subsequent _subsections_,
 - Upon keying `CTRL-D` on a _section_ prompt, the program will then generate all directories and files.
+
+### Optional Arguments
+
+```
+-n, --no-dirs         To create section markdown files rather than section
+                      folders, indices, flashcards, and subsection files.
+-t, --no-toc          To not generate a table of contents in the section files.
+                      This will only work if --no-dirs is also flagged. Useful
+                      to prevent large tables of contents in the section files
+                      when many sections are present.
+-e EXTRA, --extra EXTRA
+                      Pass in a string in markdown format to over-ride the
+                      additional formatting of the subsection files. When `--no-
+                      dirs` also flagged, this will over-ride the additional
+                      formatting of the section files. Note: best used with
+                      single quotes rather than double quotes to avoid any
+                      escaping issues present in the terminal.
+```
+
+- `-n`/`--no-dirs` is useful to create markdown files for a book, episodic material, etc. This generates only the main _course_ directory, _course index file_, and a formatted _section_ file for each supplied section - no _subsections_.
+- `t`/`--no-toc` will only generate the _table of contents_ in the _course index file_ and **not** an expanded _TOC_ in any _section_ files - but will still create a _TOC_ with a link to the _course index file_. This is useful when the book, episodic material, etc. has many sections which would create a long _TOC_.
+  - **Note:** This flag will only work when `-n`/`--no-dirs` is also flagged.
+    `-e <string>`/`--extra <string>` will over-ride the markdown headers below the _table of contents_ to the supplied markdown-formatted string.
+  - **Note:** Recommended to use _single quotes_ to handle terminal-related string issues.
+  - Example: `py course_setup_md.py -nte '## Transcript\n\n## Vocabulary\n\n## Footnotes'`
+
+```
+---
+title: Example 1 - Example Flag Usage
+tags: []
+dates: []
+---
+# 01 - Example Flag Usage
+## TOC
+- [[00-example_course|Example Course]]
+
+---
+## Transcript
+
+## Vocabulary
+
+## Footnotes
+```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Parent_Specialization_Folder/
 ```
 
 - `-n`/`--no-dirs` is useful to create markdown files for a book, episodic material, etc. This generates only the main _course_ directory, _course index file_, and a formatted _section_ file for each supplied section - no _subsections_.
-- `t`/`--no-toc` will only generate the _table of contents_ in the _course index file_ and **not** an expanded _TOC_ in any _section_ files - but will still create a _TOC_ with a link to the _course index file_. This is useful when the book, episodic material, etc. has many sections which would create a long _TOC_.
+- `-t`/`--no-toc` will only generate the _table of contents_ in the _course index file_ and **not** an expanded _TOC_ in any _section_ files - but will still create a _TOC_ with a link to the _course index file_. This is useful when the book, episodic material, etc. has many sections which would create a long _TOC_.
   - **Note:** This flag will only work when `-n`/`--no-dirs` is also flagged.
 - `-e <string>`/`--extra <string>` will over-ride the markdown headers below the _table of contents_ to the supplied markdown-formatted string.
   - **Note:** Recommended to use _single quotes_ to handle terminal-related string escape issues.

--- a/course_setup_md.py
+++ b/course_setup_md.py
@@ -571,7 +571,7 @@ def handle_title(text: str) -> str:
     Converts a string to title case, handling cases in which the string may contain Roman numerals, as well as ensuring words such as "and", "or", "the" are not capitalized unless they are the first word.
 
     Args:
-        str (str): The input string to be converted.
+        text (str): The input string to be converted.
 
     Returns:
         str: The title-cased, Roman-numeral handled version of the input string.

--- a/course_setup_md.py
+++ b/course_setup_md.py
@@ -298,8 +298,6 @@ class Section:
             )
             FileGenerator.create_markdown_file(course_index_file, course.output_dir)
 
-            ## generate section markdown file
-            # title, slug, template, filename
             if extra_section:
                 section_outline = extra_section
             else:
@@ -415,7 +413,6 @@ class Course:
                 lines.append(
                     f"- [[{sec_idx:02d}-{sec_slug}|"
                     f"{self.short_title} - {sec_idx:02d} "
-                    # f"- {section.section_title.title()}]]\n"
                     f"- {handle_title(section.section_title)}]]\n"
                 )
 
@@ -621,7 +618,6 @@ def handle_title(text: str) -> str:
     }
 
     parts = re.split(r"(\s+)", text)
-    print(parts)
     new_parts = []
     for part in parts:
         if rom_regex.match(part):

--- a/course_setup_md.py
+++ b/course_setup_md.py
@@ -9,129 +9,6 @@ INDEX_PAGE = 0  # for `00-` index pages
 FLASHCARDS_PAGE = 99  # for `99-` flashcard pages`
 
 
-def generate_slug(title: str) -> str:
-    """
-    Converts a title string into a filesystem friendly slug.
-
-    Args:
-      title (str): The input string to be converted into a slug.
-
-    Returns:
-      str: The slugified version of the input string.
-    """
-    return (
-        title.replace("(", "")
-        .replace(")", "")
-        .replace(" ", "_")
-        .replace(":", "_-")
-        .replace("/", "-")
-        .replace("?", "")
-        .replace("!", "")
-        .replace(",", "")
-        .replace("'", "")
-        .lower()
-    )
-
-
-def handle_title(text: str) -> str:
-    """
-    Converts a string to title case, handling cases in which the string may contain Roman numerals, as well as ensuring words such as "and", "or", "the" are not capitalized unless they are the first word.
-
-    Args:
-        str (str): The input string to be converted.
-
-    Returns:
-        str: The title-cased, Roman-numeral handled version of the input string.
-    """
-    rom_regex = re.compile(
-        r"^((?=[MDCLXVI])M*(C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3}))$",
-        re.IGNORECASE,
-    )
-
-    lower_case_words = {
-        "a",
-        "an",
-        "the",
-        "and",
-        "but",
-        "or",
-        "nor",
-        "for",
-        "so",
-        "yet",
-        "as",
-        "at",
-        "by",
-        "down",
-        "from",
-        "in",
-        "into",
-        "like",
-        "near",
-        "of",
-        "off",
-        "on",
-        "onto",
-        "out",
-        "over",
-        "past",
-        "per",
-        "to",
-        "up",
-        "upon",
-        "with",
-        "via",
-        "vs",
-    }
-
-    parts = re.split(r"(\s+)", text)
-    print(parts)
-    new_parts = []
-    for part in parts:
-        if rom_regex.match(part):
-            new_parts.append(part.upper())
-        else:
-            if part not in lower_case_words or part == parts[0]:
-                new_parts.append(part.capitalize())
-            else:
-                new_parts.append(part.lower())
-
-    return "".join(new_parts)
-
-
-def render_markdown(
-    title: str, table_of_contents: str, dates: bool = True, extra: str = "## Misc."
-) -> str:
-    """
-    Generate a markdown-file template, including YAML properties, and a table of contents.
-
-    Args:
-      title (str):
-        The title to be used in the YAML properties and the H1 header.
-      table_of_contents (str):
-        The supplied table of contents to render.
-      dates (bool):
-        If the YAML properties should have a dates, adds a `dates` list to the YAML properties.
-      extra (str):
-        Additional markdown to add, defaults to `## Misc.`.
-
-    Returns:
-      str: A markdown template.
-    """
-    return (
-        "---\n"
-        f'title: "{title}"\n'
-        "tags: []\n"
-        f"{'dates: []' if dates else ''}\n"
-        "---\n"
-        f"# {title}\n"
-        "## TOC\n"
-        f"{table_of_contents}\n"
-        "---\n"
-        f"{extra}"
-    )
-
-
 class FileGenerator:
     """
     Class for writing `MarkdownPage` objects to disk.
@@ -666,6 +543,129 @@ def parse_terminal_text(text: str | None) -> str | None:
     if text is None:
         return None
     return text.encode().decode("unicode_escape")
+
+
+def generate_slug(title: str) -> str:
+    """
+    Converts a title string into a filesystem friendly slug.
+
+    Args:
+      title (str): The input string to be converted into a slug.
+
+    Returns:
+      str: The slugified version of the input string.
+    """
+    return (
+        title.replace("(", "")
+        .replace(")", "")
+        .replace(" ", "_")
+        .replace(":", "_-")
+        .replace("/", "-")
+        .replace("?", "")
+        .replace("!", "")
+        .replace(",", "")
+        .replace("'", "")
+        .lower()
+    )
+
+
+def handle_title(text: str) -> str:
+    """
+    Converts a string to title case, handling cases in which the string may contain Roman numerals, as well as ensuring words such as "and", "or", "the" are not capitalized unless they are the first word.
+
+    Args:
+        str (str): The input string to be converted.
+
+    Returns:
+        str: The title-cased, Roman-numeral handled version of the input string.
+    """
+    rom_regex = re.compile(
+        r"^((?=[MDCLXVI])M*(C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3}))$",
+        re.IGNORECASE,
+    )
+
+    lower_case_words = {
+        "a",
+        "an",
+        "the",
+        "and",
+        "but",
+        "or",
+        "nor",
+        "for",
+        "so",
+        "yet",
+        "as",
+        "at",
+        "by",
+        "down",
+        "from",
+        "in",
+        "into",
+        "like",
+        "near",
+        "of",
+        "off",
+        "on",
+        "onto",
+        "out",
+        "over",
+        "past",
+        "per",
+        "to",
+        "up",
+        "upon",
+        "with",
+        "via",
+        "vs",
+    }
+
+    parts = re.split(r"(\s+)", text)
+    print(parts)
+    new_parts = []
+    for part in parts:
+        if rom_regex.match(part):
+            new_parts.append(part.upper())
+        else:
+            if part not in lower_case_words or part == parts[0]:
+                new_parts.append(part.capitalize())
+            else:
+                new_parts.append(part.lower())
+
+    return "".join(new_parts)
+
+
+def render_markdown(
+    title: str, table_of_contents: str, dates: bool = True, extra: str = "## Misc."
+) -> str:
+    """
+    Generate a markdown-file template, including YAML properties, and a table of contents.
+
+    Args:
+      title (str):
+        The title to be used in the YAML properties and the H1 header.
+      table_of_contents (str):
+        The supplied table of contents to render.
+      dates (bool):
+        If the YAML properties should have a dates, adds a `dates` list to the YAML properties.
+      extra (str):
+        Additional markdown to add, defaults to `## Misc.`.
+
+    Returns:
+      str: A markdown template.
+    """
+    return (
+        "---\n"
+        f'title: "{title}"\n'
+        "tags: []\n"
+        f"{'dates: []' if dates else ''}\n"
+        "---\n"
+        f"# {title}\n"
+        "## TOC\n"
+        f"{table_of_contents}\n"
+        "---\n"
+        f"{extra}"
+    )
 
 
 def main():

--- a/course_setup_md.py
+++ b/course_setup_md.py
@@ -32,7 +32,7 @@ def generate_slug(title: str) -> str:
     )
 
 
-def _render_markdown(
+def render_markdown(
     title: str, table_of_contents: str, dates: bool = True, extra: str = "## Misc."
 ) -> str:
     """
@@ -163,7 +163,7 @@ class Section:
     @property
     def section_template(self) -> str:
         """
-        Generates a title and passes it to the `_render_markdown()` function to create the `section_template` markdown text on the fly.
+        Generates a title and passes it to the `render_markdown()` function to create the `section_template` markdown text on the fly.
 
         Returns:
             str: Markdown-formatted text for the section index page.
@@ -171,12 +171,12 @@ class Section:
         sec_num = f"{self.index:02d}"
 
         sec_title = f"{self.course.short_title} - {sec_num}.{INDEX_PAGE:02d} - {self.section_title.title()}"
-        return _render_markdown(sec_title, self.section_toc)
+        return render_markdown(sec_title, self.section_toc)
 
     @property
     def flashcard_template(self) -> str:
         """
-        Generates a title and a list of `H2` subsection headers (as the `extra` argument) and passes to `_render_markdown()` to create the `flashcard_template` markdown on the fly.
+        Generates a title and a list of `H2` subsection headers (as the `extra` argument) and passes to `render_markdown()` to create the `flashcard_template` markdown on the fly.
 
         Returns:
             str: Markdown-formatted text for the section flashcard page, including subsection `H2` headers for each subsection.
@@ -193,7 +193,7 @@ class Section:
 
         sub_section_lines = "".join(sub_sections)
 
-        return _render_markdown(
+        return render_markdown(
             flashcards_title, self.section_toc, extra=sub_section_lines, dates=False
         )
 
@@ -321,7 +321,7 @@ class Section:
 
                 sub_extra_headers = "## Key Points/Concepts\n\n## Lecture\n\n## Misc."
 
-                sub_template: str = _render_markdown(
+                sub_template: str = render_markdown(
                     sub_title, self.section_toc, extra=sub_extra_headers
                 )
 
@@ -348,7 +348,7 @@ class Section:
 
             section_title = f"{self.course.short_title} - {self.index:02d} - {self.section_title.title()}"
             slug = self.slug
-            sub_template: str = _render_markdown(
+            sub_template: str = render_markdown(
                 section_title, self.section_toc, extra=section_outline
             )
 
@@ -461,7 +461,7 @@ class Course:
 
         table_of_contents = "".join(lines)
 
-        return _render_markdown(title, table_of_contents, dates=False)
+        return render_markdown(title, table_of_contents, dates=False)
 
     @property
     def output_dir(self) -> str:


### PR DESCRIPTION
- Adds command-line arguments:
    - `-n`/`--no-dir` - to only create the course directory, course index file, and markdown files for each section (no section folders, section index files, section flashcards, and no subsection files).
    - `-t`/`--no-toc` - to only create a TOC in the course index file, for when there are many sections or the course will continue to be updated with new files.
    - `-e <str>`/`--extra <str>` - add a markdown formatted string to over-ride the existing main-content below the TOC of a file, e.g. to change to a specific section/subsection structure.
- Adds a `handle_title()` function to capitalize Roman numerals and only capitalize title-specific words (ie not capitalizing 'of' 'for', 'the', etc.).
- Chores:
    - Code organization,
    - README file updates with expanded information on the above features